### PR TITLE
Workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
 FROM ruby:2.6
 
-ENV RAILS_ENV=test
+# Env
+ENV PHANTOMJS_VERSION 1.9.8
 
-# libnss3-dev is necessary to install google-chrome & run chromedriver-helper
-RUN apt-get update -qq && apt-get install -y libnss3-dev
+# Install phantomjs
+RUN mkdir -p /srv/var && \
+  wget -q --no-check-certificate -O /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 && \
+  tar -xjf /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -C /tmp && \
+  rm -f /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 && \
+  mv /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/ /srv/var/phantomjs && \
+  ln -s /srv/var/phantomjs/bin/phantomjs /usr/bin/phantomjs
+
+ENV RAILS_ENV=test
 
 # Install node
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
@@ -11,7 +19,10 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN mkdir /my_app
 WORKDIR /my_app
 
-COPY . /my_app
+COPY Gemfile /my_app
+COPY Gemfile.lock /my_app
 RUN bundle install
+
+COPY . /my_app
 
 CMD ["rails", "test:system"]

--- a/Gemfile
+++ b/Gemfile
@@ -47,8 +47,8 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'poltergeist'
   gem 'selenium-webdriver'
-  # Easy installation and use of web drivers to run system tests with browsers
-  gem 'webdrivers'
+  # # Easy installation and use of web drivers to run system tests with browsers
+  # gem 'webdrivers'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,10 +186,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (4.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
     webpacker (4.2.2)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -221,7 +217,6 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)
-  webdrivers
   webpacker (~> 4.0)
 
 RUBY VERSION

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,7 +1,8 @@
 require "test_helper"
 require "capybara/poltergeist"
+require "custom_system_test_case"
 
-class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+class ApplicationSystemTestCase < CustomSystemTestCase
   driven_by :poltergeist, screen_size: [1400, 1400], options:
     { js_errors: false }
 end

--- a/test/custom_system_test_case.rb
+++ b/test/custom_system_test_case.rb
@@ -1,0 +1,74 @@
+require "capybara/dsl"
+require "capybara/minitest"
+require "action_controller"
+require "action_dispatch/system_testing/driver"
+require "action_dispatch/system_testing/browser"
+require "action_dispatch/system_testing/server"
+require "action_dispatch/system_testing/test_helpers/screenshot_helper"
+require "action_dispatch/system_testing/test_helpers/setup_and_teardown"
+
+# This is basically https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/system_test_case.rb
+# witout require "selenium/webdriver"
+# Monkey patch to be able to run system tests witout chrome binary avaialble
+# See: https://github.com/rails/rails/issues/38856
+class CustomSystemTestCase < ActiveSupport::TestCase
+  include Capybara::DSL
+  include Capybara::Minitest::Assertions
+  include ActionDispatch::SystemTesting::TestHelpers::SetupAndTeardown
+  include ActionDispatch::SystemTesting::TestHelpers::ScreenshotHelper
+
+  def initialize(*) # :nodoc:
+    super
+    self.class.driven_by(:selenium) unless self.class.driver?
+    self.class.driver.use
+  end
+
+  def self.start_application # :nodoc:
+    Capybara.app = Rack::Builder.new do
+      map "/" do
+        run Rails.application
+      end
+    end
+
+    ActionDispatch::SystemTesting::Server.new.run
+  end
+
+  class_attribute :driver, instance_accessor: false
+
+  def self.driven_by(driver, using: :chrome, screen_size: [1400, 1400], options: {}, &capabilities)
+    driver_options = { using: using, screen_size: screen_size, options: options }
+
+    self.driver = ActionDispatch::SystemTesting::Driver.new(driver, **driver_options, &capabilities)
+  end
+
+  private
+
+  def url_helpers
+    @url_helpers ||=
+      if ActionDispatch.test_app
+        Class.new do
+          include ActionDispatch.test_app.routes.url_helpers
+          include ActionDispatch.test_app.routes.mounted_helpers
+
+          def url_options
+            default_url_options.reverse_merge(host: Capybara.app_host || Capybara.current_session.server_url)
+          end
+        end.new
+      end
+  end
+
+  def method_missing(name, *args, &block)
+    if url_helpers.respond_to?(name)
+      url_helpers.public_send(name, *args, &block)
+    else
+      super
+    end
+  end
+
+  def respond_to_missing?(name, _include_private = false)
+    url_helpers.respond_to?(name)
+  end
+end
+
+ActiveSupport.run_load_hooks :action_dispatch_system_test_case, CustomSystemTestCase
+CustomSystemTestCase.start_application


### PR DESCRIPTION
This PR is to make it easier to identify the differences to make Rails 6 System tests to work without a chrome binary.